### PR TITLE
fixed bug (bot printing 2 cats when only 1 needed)

### DIFF
--- a/bot/utilities/utils.py
+++ b/bot/utilities/utils.py
@@ -262,7 +262,7 @@ class UtilsCog(commands.Cog):
             else:
                 await ctx.author.edit(nick=ctx.author.name + "ᓚᘏᗢ")
         else:
-            string_list = string.split()
+            string_list = string[^:len(string)].split()
             for index, name in enumerate(string_list):
                 if "cat" in name:
                     string_list[index] = string_list[index].replace("cat", 'ᓚᘏᗢ')


### PR DESCRIPTION
The command invoking text thing (idk what to call this) is also being replaced with ᓚᘏᗢ.
As we have seen !catify cat gives out ᓚᘏᗢ ᓚᘏᗢ since the cat in the !catify also gets replaced.
Fix? Before replacing the string, make sure that the string is just the part after the command invoking thing.